### PR TITLE
Better interface for report.

### DIFF
--- a/lib/memory.rb
+++ b/lib/memory.rb
@@ -13,10 +13,17 @@ require_relative "memory/report"
 require_relative "memory/sampler"
 
 module Memory
-	def self.report(&block)
+	def self.capture(report = nil, &block)
 		sampler = Sampler.new
 		sampler.run(&block)
 		
-		return sampler.report
+		report ||= Report.general
+		report.add(sampler)
+		
+		return report
+	end
+	
+	def self.report(&block)
+		self.capture(&block)
 	end
 end

--- a/lib/memory/report.rb
+++ b/lib/memory/report.rb
@@ -26,7 +26,15 @@ module Memory
 		end
 		
 		attr :total_allocated
+		attr :total_retained
+		attr :aggregates
 		
+		# Add all samples from the given sampler to this report.
+		def add(sampler)
+			self.concat(sampler.allocated)
+		end
+		
+		# Add allocations to this report.
 		def concat(allocations)
 			allocations.each do |allocation|
 				@total_allocated << allocation
@@ -37,7 +45,7 @@ module Memory
 				end
 			end
 		end
-
+		
 		def print(io = $stderr)
 			io.puts "\# Memory Profile", nil
 			

--- a/lib/memory/sampler.rb
+++ b/lib/memory/sampler.rb
@@ -75,6 +75,9 @@ module Memory
 		
 		def start
 			GC.disable
+			3.times{GC.start}
+			
+			# Ensure any allocations related to the block are freed:
 			GC.start
 			
 			@generation = GC.count
@@ -89,6 +92,9 @@ module Memory
 			
 			GC.enable
 			3.times{GC.start}
+			
+			# See above.
+			GC.start
 			
 			ObjectSpace.each_object do |object|
 				next unless ObjectSpace.allocation_generation(object) == @generation

--- a/test/memory/report.rb
+++ b/test/memory/report.rb
@@ -7,7 +7,7 @@ require 'memory'
 
 describe Memory::Report do
 	let(:report) do
-		Memory.report do |report|
+		Memory.report do
 			Array.new
 			"Hello World".dup
 		end
@@ -33,5 +33,23 @@ describe Memory::Report do
 		)
 		
 		expect(result[:aggregates]).to have_attributes(size: be == 6)
+	end
+	
+	with 'custom report' do
+		let(:report) do
+			Memory::Report.new([
+				Memory::Aggregate.new("By Gem", &:gem),
+				Memory::Aggregate.new("By File", &:file),
+				Memory::Aggregate.new("By Class", &:class_name),
+			])
+		end
+		
+		it "captures allocations" do
+			Memory.capture(report) do
+				Array.new
+			end
+			
+			expect(report.aggregates).to have_attributes(size: be == 3)
+		end
 	end
 end


### PR DESCRIPTION
The interface for `Memory::Report` seemed inverted, so I've fixed it. Now you can create custom reports, and take samples, and add those samples into one or more report easily.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
