### PR TITLE
safely create cache with tmp locked string object

### DIFF
--- a/lib/memory/cache.rb
+++ b/lib/memory/cache.rb
@@ -56,20 +56,18 @@ module Memory
 		end
 		
 		# Look up and cache a string value.
+		#
+		# This maps the original string to a shortened representation.
+		#
 		# Strings are truncated to 64 characters to reduce memory usage.
 		# @parameter obj [String] The string object to cache.
 		# @returns [String] A cached copy of the string (truncated to 64 characters).
 		def lookup_string(obj)
-			# This string is shortened to 200 characters which is what the string report shows
-			# The string report can still list unique strings longer than 200 characters
-			#   separately because the object_id of the shortened string will be different
+			# This string is shortened to 64 characters which is what the string report shows. The string report can still list unique strings longer than 64 characters separately because the object_id of the shortened string will be different.
 			@string_cache[obj] ||= String.new << obj[0, 64]
-		rescue RuntimeError => e
-			# It is possible for the String to be temporarily locked from another Fiber
-			# which raises an error when we try to use it as a hash key.
-			# ie: Socket#read locks a buffer string while reading data into it.
-			# In this case we dup the string to get an unlocked copy.
-			if e.message == "can't modify string; temporarily locked"
+		rescue RuntimeError => error
+			# It is possible for the String to be temporarily locked from another Fiber which raises an error when we try to use it as a hash key. i.e: `Socket#read` locks a buffer string while reading data into it. In this case we `#dup`` the string to get an unlocked copy.
+			if error.message == "can't modify string; temporarily locked"
 				@string_cache[obj.dup] ||= String.new << obj[0, 64]
 			else
 				raise

--- a/memory.gemspec
+++ b/memory.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
 	spec.version = Memory::VERSION
 	
 	spec.summary = "Memory profiling routines for Ruby 2.3+"
-	spec.authors = ["Sam Saffron", "Dave Gynn", "Samuel Williams", "Nick LaMuro", "Jonas Peschla", "Ashwin Maroli", "Søren Skovsbøll", "Richard Schneeman", "Anton Davydov", "Benoit Tigeot", "Jean Boussier", "Vincent Woo", "Andrew Grimm", "Boris Staal", "Danny Ben Shitrit", "Espartaco Palma", "Florian Schwab", "Hamdi Akoğuz", "Jaiden Mispy", "John Bachir", "Luís Ferreira", "Mike Subelsky", "Olle Jonsson", "Vasily Kolesnikov", "William Tabi"]
+	spec.authors = ["Sam Saffron", "Dave Gynn", "Samuel Williams", "Nick LaMuro", "Jonas Peschla", "Ashwin Maroli", "Søren Skovsbøll", "Richard Schneeman", "Anton Davydov", "Benoit Tigeot", "Jean Boussier", "Vincent Woo", "Andrew Grimm", "Boris Staal", "Danny Ben Shitrit", "Espartaco Palma", "Florian Schwab", "Hamdi Akoğuz", "Jaiden Mispy", "John Bachir", "Luís Ferreira", "Mike Subelsky", "Olle Jonsson", "Vasily Kolesnikov", "William Tabi", "Michael Go"]
 	spec.license = "MIT"
 	
 	spec.cert_chain  = ["release.cert"]

--- a/test/memory/sampler.rb
+++ b/test/memory/sampler.rb
@@ -4,8 +4,6 @@
 # Copyright, 2020-2025, by Samuel Williams.
 
 require "memory"
-require "socket"
-require "fileutils"
 
 class MyThing
 end
@@ -42,50 +40,23 @@ describe Memory::Sampler do
 	end
 	
 	it "safely captures locked string objects" do
-		socket_path = "/tmp/test_supervisor.ipc"
-		FileUtils.rm_f(socket_path)
+		fiber = Fiber.new do |string|
+			IO::Buffer.for(string) do
+				# string is now locked for the duration of this block.
+				sleep(0.1)
+				Fiber.yield
+			end
+		end
 		
 		memory = Memory::Sampler.new
 		memory.start
 		
-		# Create server thread
-		Thread.new do
-			server = UNIXServer.new(socket_path)
-			client = server.accept
-			
-			2.times do
-				buffer = String.new(capacity: 2)
-				length_data = client.read(2, buffer) # buffer gets locked while reading
-				break unless length_data && length_data.bytesize == 2
-				
-				length = length_data.unpack1("n")
-				client.read(length)
-			end
-		ensure
-			client&.close
-			server.close
-		end
-		
-		# Create a client thread
-		Thread.new do
-			socket = UNIXSocket.new(socket_path)
-			
-			2.times do
-				message = Time.now.to_s
-				socket.write([message.bytesize].pack("n") + message)
-				puts "hello #{message}"
-				sleep(1)
-			end
-		ensure
-			socket&.close
-		end
-		
-		sleep(0.1)
+		# Lock the string
+		key = String.new("foo")
+		fiber.resume(key)
 		
 		memory.stop
 		memory.report # buffer string is locked while reading ObjectSpace#each_object
-	ensure
-		FileUtils.rm_f(socket_path)
 	end
 	
 	with "#as_json" do


### PR DESCRIPTION
## Types of Changes

- Bug fix.

## PR Summary

When `Memory::Sampler` iterates `String` objects from the `ObjectSpace`, it truncates String to reduce memory usage and caches the results. 

During this process, it is possible for the `String` objects to be internally locked. (Ruby [String#rb_str_locktmp](https://github.com/ruby/ruby/blob/35783854244f8dc6a9f7fb4dfae752f8361c66bd/string.c#L3356-L3364))

For example, when `Socket#read` is called, Ruby creates a buffer string that is temporarily locked. (Ruby [Socket#rsock_s_recvfrom](https://github.com/ruby/ruby/blob/35783854244f8dc6a9f7fb4dfae752f8361c66bd/ext/socket/init.c#L210))
If the `Memory::Sampler` creates a report when the `Socket#read` is processing, it will raise a `RuntimeError: can't modify string; temporarily locked` error:
```ruby
module Memory
  class Cache
    ...
    def lookup_string(obj)
      # since obj is internally locked, it can't be used as a Hash key
      @string_cache[obj] ||= String.new << obj[0, 64]
    end
  end
end
```

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
